### PR TITLE
Upgrade to django 1.11.24 and fix nav-bar bug

### DIFF
--- a/insitu/context_processors.py
+++ b/insitu/context_processors.py
@@ -40,7 +40,7 @@ def statistics(request):
     return {
         'products': Product.objects.all().count(),
         'requirements': Requirement.objects.all().count(),
-        'data': Data.objects.all().count(),
+        'data_count': Data.objects.all().count(),
         'data_providers': DataProvider.objects.all().count(),
         'logged_users': Session.objects.filter(expire_date__gte=timezone.now()).count(),
         'registered_users': User.objects.all().count(),

--- a/insitu/templates/nav.html
+++ b/insitu/templates/nav.html
@@ -115,7 +115,7 @@
       <p>Requirements: {{ requirements }}</p>
     </div>
     <div class="col-sm-2">
-      <p>Data: {{ data }}</p>
+      <p>Data: {{ data_count }}</p>
     </div>
     <div class="col-sm-2">
       <p>Data providers: {{ data_providers }}</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-sql-explorer==1.1.2
 django-suit==0.2.25
 django-wkhtmltopdf==3.2.0
 django-xworkflows==0.12.1
-Django==1.11.21
+Django==1.11.24
 elasticsearch-dsl==6.1.0
 openpyxl==2.4.8
 psycopg2==2.7.1


### PR DESCRIPTION
Fix: A product name would be shown in Data field (nav-bar) when user is on a product description page, instead of the real number of data elements.